### PR TITLE
feature: admin can change order status [delivers #162014477]

### DIFF
--- a/server/controllers/order.controller.js
+++ b/server/controllers/order.controller.js
@@ -248,4 +248,41 @@ export default class Order {
 			});
 		}
 	}
+
+	/**
+	 * @desc PUT api/v1/parcels/:parcelId/status
+	 * @param {object} req
+	 * @param {object} res
+	 * @returns {object} changed status order
+	 * @memberof Order
+	 */
+	static async changeOrderStatus(req, res) {
+		const { status } = req.body;
+		const parcelId = parseInt(req.params.parcelId, 0);
+		const findText = 'SELECT * FROM order WHERE id=$1';
+		const updateText =
+			'UPDATE orders SET status=$1, updated_on=$2 WHERE id=$3 returning *';
+
+		try {
+			const { rows } = await db.query(findText, [parcelId]);
+			if (!rows[0]) {
+				return res.status(404).json({
+					status: 'failure',
+					message: 'order not found'
+				});
+			}
+			const values = [status || rows[0].status, moment(new Date()), parcelId];
+			const result = await db.query(updateText, values);
+			return res.status(200).json({
+				status: 'success',
+				message: 'order status changed',
+				order: result.rows[0]
+			});
+		} catch (error) {
+			return res.status(400).json({
+				status: 'error',
+				message: 'could not change order status'
+			});
+		}
+	}
 }

--- a/server/routes/order.route.js
+++ b/server/routes/order.route.js
@@ -5,14 +5,29 @@ import Auth from '../middleware/auth';
 
 const router = Router();
 
-router.get('/parcels', Orders.getAllOrders);
-router.get('/parcels/:parcelId', Orders.getOneOrder);
+router.get('/parcels', Auth.verifyAdminToken, Orders.getAllOrders);
+router.get('/parcels/:parcelId', Auth.verifyUserToken, Orders.getOneOrder);
 router.get(
 	'/users/:userId/parcels',
 	Auth.verifyUserToken,
 	Orders.getOrdersbyUser
 );
-router.post('/parcels', validateOrder.validOrder, Orders.createOrder);
-router.put('/parcels/:parcelId/cancel', Orders.cancelOrder);
+router.post(
+	'/parcels',
+	Auth.verifyUserToken,
+	validateOrder.validOrder,
+	Orders.createOrder
+);
+router.put(
+	'/parcels/:parcelId/cancel',
+	Auth.verifyUserToken,
+	Orders.cancelOrder
+);
+router.put('/parcels/:parcelId/destination', Orders.changeOrderDestination);
+router.put(
+	'/parcels/:parcelId/status',
+	Auth.verifyAdminToken,
+	Orders.changeOrderStatus
+);
 
 export default router;


### PR DESCRIPTION
#### What does this PR do?
- An admin can change the status of a parcel delivery order

#### Description of Task to be completed?
- [x] create the endpoint for an admin to change the status of a parcel delivery order
- [x] protect the endpoint so that only an admin to perform this task
#### How should this be manually tested?

-  clone repo and `run npm install` to install dependencies
- `run npm start` or `yarn start` to start the server
- open postman
- make a PUT request to `api/v1/parcels/:parcelId/status` with the detail of the new status

#### What are the relevant pivotal tracker stories?
- story type - feature
- story title - Admin can change the status of a parcel delivery order
- story id - #162014477