### PR TITLE
feature: admin change order present location [delivers #162014693]

### DIFF
--- a/server/controllers/order.controller.js
+++ b/server/controllers/order.controller.js
@@ -285,4 +285,46 @@ export default class Order {
 			});
 		}
 	}
+
+	/**
+	 * @desc PUT api/v1/parcels/:parcelId/presentLocation
+	 * @param {object} req
+	 * @param {object} res
+	 * @returns {object} changed present location order
+	 * @memberof Order
+	 */
+	static async changeOrderPresentLocation(req, res) {
+		const { fromAddress, fromCity, fromCountry } = req.body;
+		const parcelId = parseInt(req.params.parcelId, 0);
+		const findText = 'SELECT * FROM order WHERE id=$1';
+		const updateText =
+			'UPDATE orders SET from_address=$1, from_city=$2, from_country=$3, updated_on=$4 WHERE id=$5 returning *';
+		try {
+			const { rows } = await db.query(findText, [parcelId]);
+			if (!rows[0]) {
+				return res.status(404).json({
+					status: 'failure',
+					message: 'order not found'
+				});
+			}
+			const values = [
+				fromAddress || rows[0].from_address,
+				fromCity || rows[0].from_city,
+				fromCountry || rows[0].from_country,
+				moment(new Date()),
+				parcelId
+			];
+			const result = await db.query(updateText, values);
+			return res.status(200).json({
+				status: 'success',
+				message: 'order present location changed',
+				order: result.rows[0]
+			});
+		} catch (error) {
+			return res.status(400).json({
+				status: 'error',
+				message: 'could not change order present location'
+			});
+		}
+	}
 }

--- a/server/routes/order.route.js
+++ b/server/routes/order.route.js
@@ -33,5 +33,10 @@ router.put(
 	Auth.verifyAdminToken,
 	Orders.changeOrderStatus
 );
+router.put(
+	'parcels/:parcelId/presentLocation',
+	Auth.verifyAdminToken,
+	Orders.changeOrderPresentLocation
+);
 
 export default router;


### PR DESCRIPTION
#### What does this PR do?
- An admin can change the present location of a parcel delivery order

#### Description of Task to be completed?
- [x] create the endpoint for an admin to change the present location of a parcel delivery order
- [x] protect the endpoint so that only an admin can have access

#### How should this be manually tested?
-  clone repo and `run npm install` to install dependencies
- `run npm start` or `yarn start` to start the server
- open postman
- make a PUT request to `api/v1/parcels/:parcelId/presentLocation` with the detail of the new location

#### What are the relevant pivotal tracker stories?
- story type - feature
- story title - Admin can change the present location of a parcel delivery order
- story id - #162014693