### PR TITLE
feature: user password reset endpoints [delivers #162823371]

### DIFF
--- a/client/admin.html
+++ b/client/admin.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta http-equiv="X-UA-Compatible" content="ie=edge" />
+    <link rel="icon" type="image/jpg" href="./img/pageicon.png" />
     <link rel="stylesheet" href="css/style.css" />
     <script
       defer

--- a/client/css/style.css
+++ b/client/css/style.css
@@ -469,6 +469,10 @@ span.price {
   border-left: 5px solid var(--lightblue);
 }
 
+.extras {
+  border-left: 5px solid var(--darkblue);
+}
+
 .modal {
   display: none;
   position: fixed;

--- a/client/index.html
+++ b/client/index.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta http-equiv="X-UA-Compatible" content="ie=edge" />
     <link rel="icon" type="image/jpg" href="./img/pageicon.png" />
+    <link rel="icon" type="image/jpg" href="./img/pageicon.png" />
     <link rel="stylesheet" href="css/style.css" />
     <title>SendIT | Home</title>
   </head>

--- a/server/config/db.js
+++ b/server/config/db.js
@@ -26,7 +26,7 @@ const createUsersTable = () => {
       email VARCHAR(128) UNIQUE NOT NULL,
       password VARCHAR(128) NOT NULL,
       reset_password_token VARCHAR,
-      reset_password_expires DATE,
+      reset_password_expires TIMESTAMP,
       usertype VARCHAR(10) NOT NULL DEFAULT 'user',
       created_on TIMESTAMP NOT NULL DEFAULT now(),
       updated_on TIMESTAMP NOT NULL DEFAULT now(),

--- a/server/controllers/UserController.js
+++ b/server/controllers/UserController.js
@@ -1,5 +1,6 @@
 import moment from 'moment';
 import { validationResult } from 'express-validator/check';
+import sendNotification from '../mailer/sendMail';
 
 import db from '../model';
 import Helper from '../helper/helper';
@@ -164,6 +165,7 @@ export default class UserController {
   }
 
   /**
+   *  @static
    * @desc GET api/v1/users/:userId
    * @param {object} req
    * @param {object} res
@@ -195,6 +197,141 @@ export default class UserController {
     } catch (err) {
       return res.status(500).json({
         error: 'could not get user'
+      });
+    }
+  }
+
+  /**
+   * @static
+   * @desc GET /api/v1/auth/forgotPassword
+   * @param {object} req
+   * @param {object} res
+   * @returns password reset token
+   * @memberof UserController
+   */
+  static async forgotPassword(req, res) {
+    const errors = validationResult(req);
+    const errorsMsg = {};
+    errors.array().forEach((error) => {
+      errorsMsg[error.param] = error.msg;
+    });
+    if (!errors.isEmpty()) {
+      return res.status(400).json(errorsMsg);
+    }
+    const { userEmail } = req.body;
+    const findText = 'SELECT * FROM users WHERE email = $1';
+    const updateText = 'UPDATE users SET reset_password_token=$1, reset_password_expires=$2 WHERE email=$3 returning firstname';
+    const resetToken = await Helper.generatePasswordResetToken();
+    try {
+      const { rows } = await db.query(findText, [userEmail]);
+      if (!rows[0]) {
+        return res.status(404).json({
+          message: 'User does not exist'
+        });
+      }
+      const values = [resetToken, moment(new Date(Date.now() + 3600000)), userEmail];
+      const result = await db.query(updateText, values);
+      const to = rows[0].email;
+      const user = result.rows[0].firstname;
+      const subject = 'Password reset request';
+      const message = `
+        <h3 style="text-transform:capitalize">Hello ${user},</h3>
+        <p>
+          You are receiving this email because you (or someone else) have requested 
+          the reset of the password for your account.
+        </p>
+        <p>
+          Please click on the following link, or paste this into your browser to complete the process:
+        </p>
+        <p>
+          ${req.protocol}://${req.headers.host}/resetPassword/${resetToken}
+        </p>
+        <p>
+          If you did not request this, please ignore this email and your password will remain unchanged.
+        </p>
+        <br><br>
+        <h4>From the SendIT Team</h4>
+        <p>senditparcels2018@gmail.com</p>
+      `;
+      sendNotification(to, subject, message);
+      return res.status(200).json({
+        message: 'Please check your mail for further instructions to reset your password'
+      });
+    } catch (err) {
+      return res.status(500).json({
+        error: 'Could not process with the request. Try again later',
+        err
+      });
+    }
+  }
+
+  /**
+   * The returned timestamp from the database is less that the stored
+   * timestamp by 3600000 sec (1 hr), so that amount is added to the
+   * resetTimestamp variable to make it equal to the stored timestamp
+   * for accurate comparism between the current time and the time for
+   * the token to expires which is 1hr (3600000 sec) from the time of
+   * password reset token creation.
+   * @static
+   * @desc GET /api/v1/auth/resetPassword/:resetToken
+   * @param {object} req
+   * @param {object} res
+   * @returns new password
+   * @memberof UserController
+   */
+  static async resetPassword(req, res) {
+    const errors = validationResult(req);
+    const errorsMsg = {};
+    errors.array().forEach((error) => {
+      errorsMsg[error.param] = error.msg;
+    });
+    if (!errors.isEmpty()) {
+      return res.status(400).json(errorsMsg);
+    }
+    const { resetToken } = req.params;
+    const { password } = req.body;
+    const newPassword = Helper.hashPassword(password);
+    const findText = 'SELECT * FROM users WHERE reset_password_token = $1';
+    const updateText = 'UPDATE users SET password=$1, reset_password_token=$2, reset_password_expires=$3, updated_on=$4 WHERE email=$5 returning firstname';
+    try {
+      const { rows } = await db.query(findText, [resetToken]);
+      if (!rows[0]) {
+        return res.status(404).json({
+          message: 'Password reset token is invalid'
+        });
+      }
+      const resetTimestamp = Date.parse(rows[0].reset_password_expires) + 3600000;
+      const currentTime = Date.now();
+      if (currentTime > resetTimestamp) {
+        return res.status(400).json({
+          message: 'Password reset token has expired. Please send a new reset request'
+        });
+      }
+      const values = [newPassword, null, null, moment(new Date()), rows[0].email];
+      const result = await db.query(updateText, values);
+      const to = rows[0].email;
+      const user = result.rows[0].firstname;
+      const subject = 'Password reset notification';
+      const message = `
+        <h3 style="text-transform:capitalize">Hello ${user},</h3>
+        <p>
+          This is a confirmation that the password for your account ${to} has just been changed.
+        </p>
+        <p>
+          if you did not initiate the password, please contact us ASAP at senditparcels2018@gmail.com
+        </p>
+        <br><br>
+        <h4>From the SendIT Team</h4>
+        <p>senditparcels2018@gmail.com</p>
+      `;
+      sendNotification(to, subject, message);
+      return res.status(200).json({
+        message: 'You have successfully change your password'
+      });
+    } catch (err) {
+      return res.status(500).json({
+        error: 'Could not process with the request. Try again later',
+        err
       });
     }
   }

--- a/server/helper/helper.js
+++ b/server/helper/helper.js
@@ -1,5 +1,6 @@
 import bcrypt from 'bcrypt';
 import jwt from 'jsonwebtoken';
+import crypto from 'crypto';
 
 import dotenv from 'dotenv';
 
@@ -40,5 +41,24 @@ export default class Helper {
   static generateToken(payload) {
     const token = jwt.sign(payload, process.env.JWT_SECRET, { expiresIn: '7h' });
     return token;
+  }
+
+  /**
+   * Adapted from https://stackoverflow.com/questions/8855687/secure-random-token-in-node-js
+   *Generate Password reset token
+   * @static
+   * @returns a promise
+   * @memberof Helper
+   */
+  static generatePasswordResetToken() {
+    return new Promise((resolve, reject) => {
+      crypto.randomBytes(20, (err, buffer) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve(buffer.toString('hex'));
+        }
+      });
+    });
   }
 }

--- a/server/middleware/userValidation.js
+++ b/server/middleware/userValidation.js
@@ -38,6 +38,22 @@ const validateUser = {
     check('password')
       .isLength({ min: 1 })
       .withMessage('please enter your password')
+  ],
+
+  validEmail: [
+    check('userEmail')
+      .isEmail()
+      .withMessage('invalid email')
+      .trim()
+  ],
+
+  validPassword: [
+    check('password')
+      .matches(/^(?=.*?[A-Z])(?=.*?[a-z])(?=.*?[0-9])(?=.*?[#?!@$%^&*-.]).{6,}$/)
+      .withMessage(
+        'password must be at least 6 characters with at least 1 uppercase, 1 lowercase & 1 special character'
+      )
+      .trim()
   ]
 };
 

--- a/server/routes/userRoute.js
+++ b/server/routes/userRoute.js
@@ -10,5 +10,11 @@ router.post('/auth/signup', validateUser.validSignup, UserController.create);
 router.post('/auth/login', validateUser.validLogin, UserController.login);
 router.get('/users', verifyToken, Authentications.authAdmin, UserController.getAllUsers);
 router.get('/users/:userId', verifyToken, Authentications.authAdmin, UserController.getOneUser);
+router.post('/auth/forgotPassword', validateUser.validEmail, UserController.forgotPassword);
+router.post(
+  '/auth/resetPassword/:resetToken',
+  validateUser.validPassword,
+  UserController.resetPassword
+);
 
 export default router;


### PR DESCRIPTION
#### What does this PR do?
- Endpoints for a user to request for a password reset and to reset password

#### Description of Task to be completed?
- [x] Create an endpoint for a user to request for a password reset
- [x] Use node.js crypto module to generate a random token for the password reset
- [x] send an email to the user with the link to reset password passing the resetToken as a URL  parameter
- [x] Create an endpoint for a user to reset his/her password with the token as a URL parameter

#### How should this be manually tested?
-  clone repo and `run npm install` to install dependencies
- `run npm start` or `yarn start` to start the server at `http://localhost:3001`
- open postman
- create an account with a valid active email at `http://localhost:3001/api/v1/auth/signup`
- request for a password reset at `http://localhost:3001/api/v1/auth/forgotPassword` with your account email
- go to your email and copy the randomly generated characters after resetPassword in the URL sent to your email
- add the resetToken to the URL `http://localhost:3001/api/v1/auth/resetPassword/:resetToken`
- enter your new password and send

#### What are the relevant pivotal tracker stories?
- story type - feature
- story title - User can reset his/her password
- story id - #162823371